### PR TITLE
Switch image src to use jpg instead of png

### DIFF
--- a/js/bearthday.js
+++ b/js/bearthday.js
@@ -182,7 +182,7 @@ export function renderSlide(imageSrc, caption) {
 export function buildImageUrl(date, imageName) {
   const splitDate = date.split(' '); // Don't need time smaller than day
   const datePath = splitDate[0].replace(/-/g, '/');
-  const imageSrc = `https://epic.gsfc.nasa.gov/archive/natural/${datePath}/png/${imageName}.png`;
+  const imageSrc = `https://epic.gsfc.nasa.gov/archive/natural/${datePath}/jpg/${imageName}.jpg`;
   return imageSrc;
 };
 


### PR DESCRIPTION
As per NASA's EPIC API there are multiple kinds of images https://epic.gsfc.nasa.gov/about/api stored. The the half resolution jpg is a better option for this since the pngs are very large in size and dimensions. The jpgs are big enough for what we are show.

This will load the image faster.

Link: https://epic.gsfc.nasa.gov/about/api

![Screen Shot 2019-07-02 at 1 18 49 PM](https://user-images.githubusercontent.com/1900610/60532729-f5f0bd80-9ccb-11e9-86b7-4a75643e7b2f.png)
